### PR TITLE
Add automatic JSON deserialization support for Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,34 @@ data Response a = Response
   } deriving (Show)
 ```
 
-The response body type `a` can be any type that implements the `FromResponseBody` constraint, allowing flexible handling of response data.
+The response body type `a` can be any type that implements the `FromResponseBody` constraint, allowing flexible handling of response data. Built-in supported types include `String`, `ByteString`, `Text`, and any type with a `FromJSON` instance.
+
+### JSON Response
+
+For any type with a `FromJSON` instance, the response body will be automatically decoded:
+
+```haskell
+{-# LANGUAGE DeriveGeneric #-}
+
+import Network.HTTP.Request
+import Data.Aeson (FromJSON)
+import GHC.Generics (Generic)
+
+data Date = Date
+  { __type :: String
+  , iso :: String
+  } deriving (Show, Generic)
+
+instance FromJSON Date
+
+main :: IO ()
+main = do
+  response <- get "https://api.leancloud.cn/1.1/date" :: IO (Response Date)
+  print response.status  -- 200
+  print response.body    -- Date { __type = "Date", iso = "..." }
+```
+
+If JSON decoding fails, an `AesonException` will be thrown, which can be caught with `Control.Exception.catch` or `try`.
 
 ### Without Language Extensions
 

--- a/request.cabal
+++ b/request.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Network.HTTP.Request
   build-depends:       base               >= 4.7 && < 5
+                     , aeson              >= 2.0 && < 2.3
                      , bytestring         >= 0.10.12 && < 0.13
                      , case-insensitive   >= 1.2.1 && < 1.3
                      , http-client        >= 0.6.4 && < 0.8
@@ -38,4 +39,5 @@ test-suite spec
                      , hspec
                      , bytestring         >= 0.10.12 && < 0.13
                      , text               >= 1.2.4 && < 2.2
+                     , aeson
   default-language:    Haskell2010

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,15 +1,26 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE LambdaCase  #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main where
 
+import Data.Aeson (FromJSON)
 import Data.List (isInfixOf)
+import GHC.Generics (Generic)
 import Network.HTTP.Request
 import Test.Hspec
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+
+data Date = Date
+  { __type :: String
+  , iso :: String
+  } deriving (Show, Generic)
+
+instance FromJSON Date
 
 main :: IO ()
 main = hspec $ do
@@ -74,3 +85,9 @@ main = hspec $ do
       response <- send req
       responseStatus response `shouldBe` 200
       responseBody response `shouldSatisfy` isInfixOf "🌍"
+
+    it "should parse JSON response with aeson" $ do
+      response <- get "https://api.leancloud.cn/1.1/date" :: IO (Response Date)
+      responseStatus response `shouldBe` 200
+      __type (responseBody response) `shouldBe` "Date"
+      iso (responseBody response) `shouldSatisfy` not . null


### PR DESCRIPTION
Any type with a FromJSON instance can now be used directly as Response body type, e.g. `Response MyType`. The FromResponseBody typeclass signature is changed to return `Either String a`, throwing AesonException on decode failure instead of using `error`.