### PR TITLE
Add ToForm class and Form newtype for url-encoded bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Built-in `ToRequestBody` instances and their inferred `Content-Type`:
 - `()` → empty body, no Content-Type
 - `ByteString` / lazy `ByteString` / `Text` / `String` → `text/plain; charset=utf-8`
 - Any type with a `ToJSON` instance → auto JSON encoding + `application/json`
+- `Form a` (where `a` has a `ToForm` instance) → URL-encoded + `application/x-www-form-urlencoded`
 
 The `Content-Type` is automatically inferred from the body type. You can override it by setting the header manually:
 
@@ -146,6 +147,70 @@ main = do
   response <- post "https://httpbin.org/post" (User "Alice") :: IO (Response String)
   print response.status  -- 200
 ```
+
+## Form Support
+
+For `application/x-www-form-urlencoded` requests (login forms, OAuth token endpoints, classic web APIs), wrap your body in the `Form` newtype. The `Content-Type` is set automatically and values are percent-encoded.
+
+### From a list of pairs
+
+```haskell
+import Network.HTTP.Request
+
+main :: IO ()
+main = do
+  response <- post "https://httpbin.org/post"
+                   (Form [("username", "alice"), ("password", "s3cret")])
+              :: IO (Response String)
+  print response.status  -- 200
+  -- Body sent: username=alice&password=s3cret
+```
+
+Values are `ByteString` keys and values. Special characters (spaces, Unicode, reserved chars) are percent-encoded for you:
+
+```haskell
+post "https://api.example.com/search"
+     (Form [("q", "hello world"), ("lang", "zh-CN")])
+-- Body sent: q=hello%20world&lang=zh-CN
+```
+
+### From a custom type
+
+For your own record types, define a `ToForm` instance. This mirrors the `ToJSON` pattern:
+
+```haskell
+import Network.HTTP.Request
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+data Login = Login
+  { username :: T.Text
+  , password :: T.Text
+  }
+
+instance ToForm Login where
+  toForm l = [ ("username", T.encodeUtf8 l.username)
+             , ("password", T.encodeUtf8 l.password)
+             ]
+
+main :: IO ()
+main = do
+  response <- post "https://api.example.com/login"
+                   (Form (Login "alice" "s3cret"))
+              :: IO (Response String)
+  print response.status
+```
+
+### The two new pieces of API
+
+```haskell
+class ToForm a where
+  toForm :: a -> [(ByteString, ByteString)]
+
+newtype Form a = Form a
+```
+
+The `Form` newtype is required to disambiguate the form-encoding path from JSON. Without it, a type that has both `ToJSON` and `ToForm` instances would be ambiguous; with it, `post url x` always means JSON and `post url (Form x)` always means form.
 
 ## Shortcuts
 

--- a/src/Network/HTTP/Request.hs
+++ b/src/Network/HTTP/Request.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Network.HTTP.Request
@@ -11,6 +13,8 @@ module Network.HTTP.Request
     Headers,
     FromResponseBody (..),
     ToRequestBody (..),
+    ToForm (..),
+    Form (..),
     Manager,
     Method (..),
     Request (..),
@@ -49,6 +53,7 @@ import Network.HTTP.Client (Manager)
 import qualified Network.HTTP.Client as LowLevelClient
 import qualified Network.HTTP.Client.TLS as LowLevelTLSClient
 import qualified Network.HTTP.Types.Status as LowLevelStatus
+import Network.HTTP.Types.URI (renderSimpleQuery)
 
 type Header = (BS.ByteString, BS.ByteString)
 
@@ -199,6 +204,18 @@ instance {-# OVERLAPPABLE #-} (ToJSON a) => ToRequestBody a where
 instance ToRequestBody () where
   toRequestBody () = BS.empty
   requestContentType () = Nothing
+
+class ToForm a where
+  toForm :: a -> [(BS.ByteString, BS.ByteString)]
+
+instance (k ~ BS.ByteString, v ~ BS.ByteString) => ToForm [(k, v)] where
+  toForm = id
+
+newtype Form a = Form a
+
+instance (ToForm a) => ToRequestBody (Form a) where
+  toRequestBody (Form a) = renderSimpleQuery False (toForm a)
+  requestContentType _ = Just "application/x-www-form-urlencoded"
 
 data Method
   = DELETE

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -29,6 +29,16 @@ data Greeting = Greeting
 
 instance ToJSON Greeting
 
+data Login = Login
+  { username :: T.Text
+  , password :: T.Text
+  } deriving (Show)
+
+instance ToForm Login where
+  toForm l = [ ("username", T.encodeUtf8 l.username)
+             , ("password", T.encodeUtf8 l.password)
+             ]
+
 main :: IO ()
 main = hspec $ do
   describe "Network.HTTP.Request" $ do
@@ -105,6 +115,25 @@ main = hspec $ do
       response <- post "https://postman-echo.com/post" (Greeting "Hello!") :: IO (Response String)
       responseStatus response `shouldBe` 200
       responseBody response `shouldSatisfy` isInfixOf "application/json"
+
+    it "should post url-encoded form from a list" $ do
+      response <- post "https://postman-echo.com/post" (Form [("foo", "bar"), ("baz", "qux")]) :: IO (Response String)
+      responseStatus response `shouldBe` 200
+      responseBody response `shouldSatisfy` isInfixOf "application/x-www-form-urlencoded"
+      responseBody response `shouldSatisfy` isInfixOf "\"foo\":\"bar\""
+      responseBody response `shouldSatisfy` isInfixOf "\"baz\":\"qux\""
+
+    it "should post url-encoded form from a ToForm instance" $ do
+      response <- post "https://postman-echo.com/post" (Form (Login "alice" "s3cret")) :: IO (Response String)
+      responseStatus response `shouldBe` 200
+      responseBody response `shouldSatisfy` isInfixOf "application/x-www-form-urlencoded"
+      responseBody response `shouldSatisfy` isInfixOf "\"username\":\"alice\""
+      responseBody response `shouldSatisfy` isInfixOf "\"password\":\"s3cret\""
+
+    it "should percent-encode form values with special characters" $ do
+      response <- post "https://postman-echo.com/post" (Form [("q", "hello world"), ("lang", "zh-CN")]) :: IO (Response String)
+      responseStatus response `shouldBe` 200
+      responseBody response `shouldSatisfy` isInfixOf "\"q\":\"hello world\""
 
     it "should add default User-Agent when request header is missing" $ do
       response <- send (Request GET "https://postman-echo.com/get" [] ()) :: IO (Response String)


### PR DESCRIPTION
Adds an `application/x-www-form-urlencoded` path that mirrors the existing `ToJSON` workflow: a `ToForm` class plus a `Form a` newtype wrapper. The wrapper disambiguates form from JSON (`post url x` is JSON, `post url (Form x)` is form). A built-in instance for `[(ByteString, ByteString)]` lets inline literals work without annotations.

Usage:

    post url (Form [("k","v")])
    post url (Form (Login "alice" "s3cret"))  -- requires `instance ToForm Login`

New tests cover list bodies, custom `ToForm` records, and percent-encoding of special characters. Existing JSON / plain-body / streaming tests still pass.