### PR TITLE
fix: replace dead sse.dev with Wikimedia SSE stream in test

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -160,7 +160,7 @@ main = hspec $ do
       mChunk `shouldSatisfy` (/= Nothing)
 
     it "should parse and stream SSE events" $ do
-      let req = Request GET "https://sse.dev/test" [] ()
+      let req = Request GET "https://stream.wikimedia.org/v2/stream/recentchange" [] ()
       resp <- send req :: IO (Response (StreamBody SseEvent))
       resp.status `shouldBe` 200
       mEvent <- resp.body.readNext


### PR DESCRIPTION
sse.dev is down, test uses Wikimedia recentchange SSE stream instead.